### PR TITLE
Initial resolution setting fix (along with other resolution fixes)

### DIFF
--- a/patches/64bit/Terraria.ModLoader.x64bit/Core64.cs
+++ b/patches/64bit/Terraria.ModLoader.x64bit/Core64.cs
@@ -307,5 +307,19 @@ namespace Terraria.ModLoader.x64bit
 				}
 			}
 		}
+
+		public static void DoClientSizeChanged(Object sender, EventArgs e)
+		{
+			var window = sender as GameWindow;
+			// We remove the event in case SetResolution changes the window size again.
+			window.ClientSizeChanged -= DoClientSizeChanged;
+			if (Main.graphics.IsFullScreen) {
+				Main.SetResolution(Main.PendingResolutionWidth, Main.PendingResolutionHeight);
+			}
+			else {
+				Main.SetResolution(window.ClientBounds.Width, window.ClientBounds.Height);
+			}
+			window.ClientSizeChanged += DoClientSizeChanged;
+		}
 	}
 }

--- a/patches/64bit/Terraria/Main.cs.patch
+++ b/patches/64bit/Terraria/Main.cs.patch
@@ -169,7 +169,7 @@
  			});
  
  			base.Initialize();
-+			base.Window.ClientSizeChanged += DoClientSizeChanged;
++			base.Window.ClientSizeChanged += Core64.DoClientSizeChanged;
  			base.Window.AllowUserResizing = true;
  			OpenSettings();
  			if (screenWidth > GraphicsAdapter.DefaultAdapter.CurrentDisplayMode.Width)
@@ -401,22 +401,9 @@
  				if (!fullscreen) {
  					form.SendToBack();
  					form.BringToFront();
-@@ -51019,8 +_,19 @@
- 			UIScale = UIScaleWanted;
+@@ -51020,7 +_,6 @@
  		}
  
-+		private void DoClientSizeChanged(Object sender, EventArgs e)
-+		{
-+			// We remove the event in case SetResolution changes the window size again.
-+			Window.ClientSizeChanged -= DoClientSizeChanged;
-+			if (graphics.IsFullScreen) {
-+				SetResolution(PendingResolutionWidth, PendingResolutionHeight);
-+			} else {
-+				SetResolution(Window.ClientBounds.Width, Window.ClientBounds.Height);
-+			}
-+			Window.ClientSizeChanged += DoClientSizeChanged;
-+		}
-+
  		public void UpdateDisplaySettings() {
 -			SetResolution(base.GraphicsDevice.Viewport.Width, base.GraphicsDevice.Viewport.Height);
  		}

--- a/patches/64bit/Terraria/Main.cs.patch
+++ b/patches/64bit/Terraria/Main.cs.patch
@@ -165,6 +165,14 @@
  			string vanillaContentFolder = "../Terraria/Content"; // Side-by-Side Manual Install
  			if (!Directory.Exists(vanillaContentFolder)) {
  				vanillaContentFolder = "../Content"; // Nested Manual Install
+@@ -6757,6 +_,7 @@
+ 			});
+ 
+ 			base.Initialize();
++			base.Window.ClientSizeChanged += DoClientSizeChanged;
+ 			base.Window.AllowUserResizing = true;
+ 			OpenSettings();
+ 			if (screenWidth > GraphicsAdapter.DefaultAdapter.CurrentDisplayMode.Width)
 @@ -7473,7 +_,7 @@
  			if (waveBank == null) //supress extra exceptions from audio engine failing to load
  				return;
@@ -336,7 +344,14 @@
  			screenMaximized = (((Form)Control.FromHandle(instance.Window.Handle)).WindowState == FormWindowState.Maximized);
  			if (screenBorderless && screenMaximized && !graphics.IsFullScreen) {
  				screenMaximized = false;
-@@ -50891,7 +_,7 @@
+@@ -50884,14 +_,11 @@
+ #else
+ 			Main.screenMaximized = false;
+ #endif
+-			if (!instance.IsActive && (screenBorderless || screenMaximized || graphics.IsFullScreen))
+-				return;
+-
+ 			bool flag2 = false;
  			int num3;
  			int num4;
  			if (screenBorderless || screenMaximized || graphics.IsFullScreen) {
@@ -345,7 +360,11 @@
  				form.MinimumSize = new Size(0, 0);
  				if (screenBorderless && !graphics.IsFullScreen && screenBorderlessPendingResizes > 0) {
  					screenBorderlessPendingResizes--;
-@@ -50925,7 +_,7 @@
+@@ -50922,10 +_,11 @@
+ 				else {
+ 					num3 = graphics.PreferredBackBufferWidth;
+ 					num4 = graphics.PreferredBackBufferHeight;
++					flag2 = (graphics.PreferredBackBufferWidth != graphics.GraphicsDevice.Viewport.Width || graphics.PreferredBackBufferHeight != graphics.GraphicsDevice.Viewport.Height);
  				}
  			}
  			else {
@@ -363,6 +382,16 @@
  			// appears redundant. Just causes the window to fight the user when attempting to resize too small
  			// with this disabled, the window will just snap back to minimum size when released
  			/*if (!fullscreen && !flag2) {
+@@ -50970,8 +_,7 @@
+ 				screenHeight = height;
+ 				graphics.PreferredBackBufferWidth = screenWidth;
+ 				graphics.PreferredBackBufferHeight = screenHeight;
+-				if (width != num3 || height != num4) //avoid resetting the device when it doesn't need resizing
+-					graphics.ApplyChanges();
++				graphics.ApplyChanges();
+ 
+ 				PlayerInput.CacheOriginalScreenDimensions();
+ 				FixUIScale();
 @@ -50981,7 +_,7 @@
  				PendingResolutionWidth = screenWidth;
  				PendingResolutionHeight = screenHeight;
@@ -372,3 +401,24 @@
  				if (!fullscreen) {
  					form.SendToBack();
  					form.BringToFront();
+@@ -51019,8 +_,19 @@
+ 			UIScale = UIScaleWanted;
+ 		}
+ 
++		private void DoClientSizeChanged(Object sender, EventArgs e)
++		{
++			// We remove the event in case SetResolution changes the window size again.
++			Window.ClientSizeChanged -= DoClientSizeChanged;
++			if (graphics.IsFullScreen) {
++				SetResolution(PendingResolutionWidth, PendingResolutionHeight);
++			} else {
++				SetResolution(Window.ClientBounds.Width, Window.ClientBounds.Height);
++			}
++			Window.ClientSizeChanged += DoClientSizeChanged;
++		}
++
+ 		public void UpdateDisplaySettings() {
+-			SetResolution(base.GraphicsDevice.Viewport.Width, base.GraphicsDevice.Viewport.Height);
+ 		}
+ 
+ 		public static void OpenPlayerSelect(OnPlayerSelected method) {


### PR DESCRIPTION
### What is the bug?

On startup, the resolution is set to 800x600, rather than the configured one. Also, going to full screen always switches to the desktop resolution, and no other resolutions seem to work.

### How did you fix the bug?

I prevented tML from attempting to set the resolution every frame, and instead have it only setting the resolution when the window size is changed, either by dragging the window frame or by going to/from full screen. The set resolution will be used.

### Are there alternatives to your fix?

It is possible to fix the initial issue without fixing the rest of the issues, but it's not nearly as good of a user experience.

### Caveats

Currently, Terraria still uses one resolution for both the windowed and full screen setting. This can cause some oddities to occur, like trying to set the fullscreen resolution to something like 1111x777. However, this still works fine because FNA will only set a fullscreen resolution to the same as the desktop resolution. Any other resolution is scaled. This ends up working out well enough.