### PR TITLE
Convert 64Bit Strings to Localizable Text

### DIFF
--- a/patches/64bit/Terraria.IO/WorldFileData.cs.patch
+++ b/patches/64bit/Terraria.IO/WorldFileData.cs.patch
@@ -5,7 +5,7 @@
  					_worldSizeName = Language.GetText("UI.WorldSizeLarge");
  					break;
 +				case 16800:
-+					_worldSizeName = Language.GetText("XL");
++					_worldSizeName = Language.GetText("tModLoader.XL");
 +					break;
  				default:
  					_worldSizeName = Language.GetText("UI.WorldSizeUnknown");

--- a/patches/64bit/Terraria.Localization.Content/de-DE.tModLoader.json.patch
+++ b/patches/64bit/Terraria.Localization.Content/de-DE.tModLoader.json.patch
@@ -1,12 +1,26 @@
 --- src/tModLoader/Terraria.Localization.Content/de-DE.tModLoader.json
 +++ src/64bit/Terraria.Localization.Content/de-DE.tModLoader.json
-@@ -348,6 +_,10 @@
+@@ -348,6 +_,24 @@
  		"WorldIODataException": "Das Spiel hat ein Mod-Datei Problem bei dieser Welt festgestellt.",
  		"ServerCrash": "Server crash: {0}\n{1}\n\nBitte checke server.log um festzustellen ob eine Mod daran schuld ist, ansonsten gehe in den #support Kanal im tModLoader Discord!"
  
 +		// Misc. 64bit
 +		//"XL": "XL",
-+  //"Support": "Support",
++		//"Support": "Support",
++		//"64bitDiscord": "tModLoader 64bit Discord",
++		//"tModDiscord": "Official tModLoader Discord",
++		//"PatreonDradon": "Support Dradon on Patreon!",
++		//"PatreontMod": "Support tModLoader on Patreon!",
++		//"VanillaMode": "Switch to 64bit vanillla",
++		//"tModMode": "Switch to 64bit tML",
++		//"DisableLite": "Disable Lite mode",
++		//"EnableLite": "Enable Lite mode",
++		//"RunningBitMode": "(Running in {0}bit mode)",
++		//"GoG": "GoG",
++		//"Steam": "Steam",
++		//"UnfinishedFeature": "This feature is NOT finshed and will be released at a later date.\n\n\n- Dradonhunter11",
++		//"SwitchFromLite": "Your game will be switched to the full 64bit version. You will need to restart your game completely for all effects to be applied.\nIn this mode, you can generate XL worlds and larger chest limit of 2000; however, you will no longer be able to play with 32bit tML users anymore unless you switch back to Lite mode.",
++		//"SwitchToLite": "Your game will be switched to the Lite version of 64bit. You will need to restart your game completely for all effects to be applied.\nIn this mode, you will be able to play with other 32bit tML users (along with other 64bit Lite users); however, you will not be able to player with tML 64bit users who are not using the Lite version. You can always switch back to the full version of 64bit tML.",
 +
  		// MessageBox
  		// "ContentFolderNotFound": "Terraria Content folder not found. If you installed tModLoader through Steam, make sure that Terraria is installed. If not, make sure to install tModLoader in a folder nested within the Terraria install directory or a folder next to the Terraria install directory.",

--- a/patches/64bit/Terraria.Localization.Content/de-DE.tModLoader.json.patch
+++ b/patches/64bit/Terraria.Localization.Content/de-DE.tModLoader.json.patch
@@ -1,11 +1,12 @@
 --- src/tModLoader/Terraria.Localization.Content/de-DE.tModLoader.json
 +++ src/64bit/Terraria.Localization.Content/de-DE.tModLoader.json
-@@ -348,6 +_,9 @@
+@@ -348,6 +_,10 @@
  		"WorldIODataException": "Das Spiel hat ein Mod-Datei Problem bei dieser Welt festgestellt.",
  		"ServerCrash": "Server crash: {0}\n{1}\n\nBitte checke server.log um festzustellen ob eine Mod daran schuld ist, ansonsten gehe in den #support Kanal im tModLoader Discord!"
  
 +		// Misc. 64bit
 +		//"XL": "XL",
++  //"Support": "Support",
 +
  		// MessageBox
  		// "ContentFolderNotFound": "Terraria Content folder not found. If you installed tModLoader through Steam, make sure that Terraria is installed. If not, make sure to install tModLoader in a folder nested within the Terraria install directory or a folder next to the Terraria install directory.",

--- a/patches/64bit/Terraria.Localization.Content/de-DE.tModLoader.json.patch
+++ b/patches/64bit/Terraria.Localization.Content/de-DE.tModLoader.json.patch
@@ -1,0 +1,12 @@
+--- src/tModLoader/Terraria.Localization.Content/de-DE.tModLoader.json
++++ src/64bit/Terraria.Localization.Content/de-DE.tModLoader.json
+@@ -348,6 +_,9 @@
+ 		"WorldIODataException": "Das Spiel hat ein Mod-Datei Problem bei dieser Welt festgestellt.",
+ 		"ServerCrash": "Server crash: {0}\n{1}\n\nBitte checke server.log um festzustellen ob eine Mod daran schuld ist, ansonsten gehe in den #support Kanal im tModLoader Discord!"
+ 
++		// Misc. 64bit
++		//"XL": "XL",
++
+ 		// MessageBox
+ 		// "ContentFolderNotFound": "Terraria Content folder not found. If you installed tModLoader through Steam, make sure that Terraria is installed. If not, make sure to install tModLoader in a folder nested within the Terraria install directory or a folder next to the Terraria install directory.",
+ 		// "MissingServerExecutable": "Looks like you didn't do a complete install. You are missing tModLoaderServer.exe. Check your install directory and read the install directions.",

--- a/patches/64bit/Terraria.Localization.Content/en-US.tModLoader.json.patch
+++ b/patches/64bit/Terraria.Localization.Content/en-US.tModLoader.json.patch
@@ -1,11 +1,12 @@
 --- src/tModLoader/Terraria.Localization.Content/en-US.tModLoader.json
 +++ src/64bit/Terraria.Localization.Content/en-US.tModLoader.json
-@@ -348,6 +_,9 @@
+@@ -348,6 +_,10 @@
  		"WorldIODataException": "The game encountered a mod data problem for a world.",
  		"ServerCrash": "Server crash: {0}\n{1}\n\nPlease check server.log to determine if a mod is responsible, otherwise head to #support in the tModLoader Discord",
  
 +		// Misc. 64bit
 +		"XL": "XL",
++  "Support": "Support",
 +
  		// MessageBox
  		"ContentFolderNotFound": "Terraria Content folder not found. If you installed tModLoader through Steam, make sure that Terraria is installed. If not, make sure to install tModLoader in a folder nested within the Terraria install directory or a folder next to the Terraria install directory.",

--- a/patches/64bit/Terraria.Localization.Content/en-US.tModLoader.json.patch
+++ b/patches/64bit/Terraria.Localization.Content/en-US.tModLoader.json.patch
@@ -1,6 +1,6 @@
 --- src/tModLoader/Terraria.Localization.Content/en-US.tModLoader.json
 +++ src/64bit/Terraria.Localization.Content/en-US.tModLoader.json
-@@ -348,6 +_,14 @@
+@@ -348,6 +_,24 @@
  		"WorldIODataException": "The game encountered a mod data problem for a world.",
  		"ServerCrash": "Server crash: {0}\n{1}\n\nPlease check server.log to determine if a mod is responsible, otherwise head to #support in the tModLoader Discord",
  
@@ -11,6 +11,16 @@
 +		"tModDiscord": "Official tModLoader Discord",
 +		"PatreonDradon": "Support Dradon on Patreon!",
 +		"PatreontMod": "Support tModLoader on Patreon!",
++		"VanillaMode": "Switch to 64bit vanillla",
++		"tModMode": "Switch to 64bit tML",
++		"DisableLite": "Disable Lite mode",
++		"EnableLite": "Enable Lite mode",
++		"RunningBitMode": "(Running in {0}bit mode)",
++		"GoG": "GoG",
++		"Steam": "Steam",
++		"UnfinishedFeature": "This feature is NOT finshed and will be released at a later date.\n\n\n- Dradonhunter11",
++		"SwitchFromLite": "Your game will be switched to the full 64bit version. You will need to restart your game completely for all effects to be applied.\nIn this mode, you can generate XL worlds and larger chest limit of 2000; however, you will no longer be able to play with 32bit tML users anymore unless you switch back to Lite mode.",
++		"SwitchToLite": "Your game will be switched to the Lite version of 64bit. You will need to restart your game completely for all effects to be applied.\nIn this mode, you will be able to play with other 32bit tML users (along with other 64bit Lite users); however, you will not be able to player with tML 64bit users who are not using the Lite version. You can always switch back to the full version of 64bit tML.",
 +
  		// MessageBox
  		"ContentFolderNotFound": "Terraria Content folder not found. If you installed tModLoader through Steam, make sure that Terraria is installed. If not, make sure to install tModLoader in a folder nested within the Terraria install directory or a folder next to the Terraria install directory.",

--- a/patches/64bit/Terraria.Localization.Content/en-US.tModLoader.json.patch
+++ b/patches/64bit/Terraria.Localization.Content/en-US.tModLoader.json.patch
@@ -1,0 +1,12 @@
+--- src/tModLoader/Terraria.Localization.Content/en-US.tModLoader.json
++++ src/64bit/Terraria.Localization.Content/en-US.tModLoader.json
+@@ -348,6 +_,9 @@
+ 		"WorldIODataException": "The game encountered a mod data problem for a world.",
+ 		"ServerCrash": "Server crash: {0}\n{1}\n\nPlease check server.log to determine if a mod is responsible, otherwise head to #support in the tModLoader Discord",
+ 
++		// Misc. 64bit
++		"XL": "XL",
++
+ 		// MessageBox
+ 		"ContentFolderNotFound": "Terraria Content folder not found. If you installed tModLoader through Steam, make sure that Terraria is installed. If not, make sure to install tModLoader in a folder nested within the Terraria install directory or a folder next to the Terraria install directory.",
+ 		"MissingServerExecutable": "Looks like you didn't do a complete install. You are missing tModLoaderServer.exe. Check your install directory and read the install directions.",

--- a/patches/64bit/Terraria.Localization.Content/en-US.tModLoader.json.patch
+++ b/patches/64bit/Terraria.Localization.Content/en-US.tModLoader.json.patch
@@ -1,12 +1,16 @@
 --- src/tModLoader/Terraria.Localization.Content/en-US.tModLoader.json
 +++ src/64bit/Terraria.Localization.Content/en-US.tModLoader.json
-@@ -348,6 +_,10 @@
+@@ -348,6 +_,14 @@
  		"WorldIODataException": "The game encountered a mod data problem for a world.",
  		"ServerCrash": "Server crash: {0}\n{1}\n\nPlease check server.log to determine if a mod is responsible, otherwise head to #support in the tModLoader Discord",
  
 +		// Misc. 64bit
 +		"XL": "XL",
-+  "Support": "Support",
++		"Support": "Support",
++		"64bitDiscord": "tModLoader 64bit Discord",
++		"tModDiscord": "Official tModLoader Discord",
++		"PatreonDradon": "Support Dradon on Patreon!",
++		"PatreontMod": "Support tModLoader on Patreon!",
 +
  		// MessageBox
  		"ContentFolderNotFound": "Terraria Content folder not found. If you installed tModLoader through Steam, make sure that Terraria is installed. If not, make sure to install tModLoader in a folder nested within the Terraria install directory or a folder next to the Terraria install directory.",

--- a/patches/64bit/Terraria.Localization.Content/es-ES.tModLoader.json.patch
+++ b/patches/64bit/Terraria.Localization.Content/es-ES.tModLoader.json.patch
@@ -1,12 +1,16 @@
 --- src/tModLoader/Terraria.Localization.Content/es-ES.tModLoader.json
 +++ src/64bit/Terraria.Localization.Content/es-ES.tModLoader.json
-@@ -348,6 +_,10 @@
+@@ -348,6 +_,14 @@
  		"WorldIODataException": "Se ha encontrado un error en los datos de un mod para un mundo.",
  		"ServerCrash": "Servidor caído: {0}\n{1}\n\nPor favor, comprueba server.log para determinar si el responsable es un mod. En caso contrario, dirígete a #support en el Discord de tModLoader",
  
 +		// Misc. 64bit
 +		//"XL": "XL",
-+  //"Support": "Support",
++		//"Support": "Support",
++		//"64bitDiscord": "tModLoader 64bit Discord",
++		//"tModDiscord": "Official tModLoader Discord",
++		//"PatreonDradon": "Support Dradon on Patreon!",
++		//"PatreontMod": "Support tModLoader on Patreon!",
 +
  		// MessageBox
  		"ContentFolderNotFound": "No se ha encontrado la carpeta de contenido de Terraria. Si instalaste tModLoader a través de Steam, asegúrate de que Terraria esté instalado. Si no, asegúrate de instalar el tModLoader en una carpeta ubicada dentro del directorio de instalación de Terraria o en una carpeta junto al directorio de instalación de Terraria.",

--- a/patches/64bit/Terraria.Localization.Content/es-ES.tModLoader.json.patch
+++ b/patches/64bit/Terraria.Localization.Content/es-ES.tModLoader.json.patch
@@ -1,0 +1,12 @@
+--- src/tModLoader/Terraria.Localization.Content/es-ES.tModLoader.json
++++ src/64bit/Terraria.Localization.Content/es-ES.tModLoader.json
+@@ -348,6 +_,9 @@
+ 		"WorldIODataException": "Se ha encontrado un error en los datos de un mod para un mundo.",
+ 		"ServerCrash": "Servidor caído: {0}\n{1}\n\nPor favor, comprueba server.log para determinar si el responsable es un mod. En caso contrario, dirígete a #support en el Discord de tModLoader",
+ 
++		// Misc. 64bit
++		//"XL": "XL",
++
+ 		// MessageBox
+ 		"ContentFolderNotFound": "No se ha encontrado la carpeta de contenido de Terraria. Si instalaste tModLoader a través de Steam, asegúrate de que Terraria esté instalado. Si no, asegúrate de instalar el tModLoader en una carpeta ubicada dentro del directorio de instalación de Terraria o en una carpeta junto al directorio de instalación de Terraria.",
+ 		"MissingServerExecutable": "Parece que no has completado la instalación. Falta tModLoaderServer.exe. Revisa el directorio de instalación y lee las instrucciones de instalación.",

--- a/patches/64bit/Terraria.Localization.Content/es-ES.tModLoader.json.patch
+++ b/patches/64bit/Terraria.Localization.Content/es-ES.tModLoader.json.patch
@@ -1,6 +1,6 @@
 --- src/tModLoader/Terraria.Localization.Content/es-ES.tModLoader.json
 +++ src/64bit/Terraria.Localization.Content/es-ES.tModLoader.json
-@@ -348,6 +_,14 @@
+@@ -348,6 +_,24 @@
  		"WorldIODataException": "Se ha encontrado un error en los datos de un mod para un mundo.",
  		"ServerCrash": "Servidor caído: {0}\n{1}\n\nPor favor, comprueba server.log para determinar si el responsable es un mod. En caso contrario, dirígete a #support en el Discord de tModLoader",
  
@@ -11,6 +11,16 @@
 +		//"tModDiscord": "Official tModLoader Discord",
 +		//"PatreonDradon": "Support Dradon on Patreon!",
 +		//"PatreontMod": "Support tModLoader on Patreon!",
++		//"VanillaMode": "Switch to 64bit vanillla",
++		//"tModMode": "Switch to 64bit tML",
++		//"DisableLite": "Disable Lite mode",
++		//"EnableLite": "Enable Lite mode",
++		//"RunningBitMode": "(Running in {0}bit mode)",
++		//"GoG": "GoG",
++		//"Steam": "Steam",
++		//"UnfinishedFeature": "This feature is NOT finshed and will be released at a later date.\n\n\n- Dradonhunter11",
++		//"SwitchFromLite": "Your game will be switched to the full 64bit version. You will need to restart your game completely for all effects to be applied.\nIn this mode, you can generate XL worlds and larger chest limit of 2000; however, you will no longer be able to play with 32bit tML users anymore unless you switch back to Lite mode.",
++		//"SwitchToLite": "Your game will be switched to the Lite version of 64bit. You will need to restart your game completely for all effects to be applied.\nIn this mode, you will be able to play with other 32bit tML users (along with other 64bit Lite users); however, you will not be able to player with tML 64bit users who are not using the Lite version. You can always switch back to the full version of 64bit tML.",
 +
  		// MessageBox
  		"ContentFolderNotFound": "No se ha encontrado la carpeta de contenido de Terraria. Si instalaste tModLoader a través de Steam, asegúrate de que Terraria esté instalado. Si no, asegúrate de instalar el tModLoader en una carpeta ubicada dentro del directorio de instalación de Terraria o en una carpeta junto al directorio de instalación de Terraria.",

--- a/patches/64bit/Terraria.Localization.Content/es-ES.tModLoader.json.patch
+++ b/patches/64bit/Terraria.Localization.Content/es-ES.tModLoader.json.patch
@@ -1,11 +1,12 @@
 --- src/tModLoader/Terraria.Localization.Content/es-ES.tModLoader.json
 +++ src/64bit/Terraria.Localization.Content/es-ES.tModLoader.json
-@@ -348,6 +_,9 @@
+@@ -348,6 +_,10 @@
  		"WorldIODataException": "Se ha encontrado un error en los datos de un mod para un mundo.",
  		"ServerCrash": "Servidor caído: {0}\n{1}\n\nPor favor, comprueba server.log para determinar si el responsable es un mod. En caso contrario, dirígete a #support en el Discord de tModLoader",
  
 +		// Misc. 64bit
 +		//"XL": "XL",
++  //"Support": "Support",
 +
  		// MessageBox
  		"ContentFolderNotFound": "No se ha encontrado la carpeta de contenido de Terraria. Si instalaste tModLoader a través de Steam, asegúrate de que Terraria esté instalado. Si no, asegúrate de instalar el tModLoader en una carpeta ubicada dentro del directorio de instalación de Terraria o en una carpeta junto al directorio de instalación de Terraria.",

--- a/patches/64bit/Terraria.Localization.Content/fr-FR.tModLoader.json.patch
+++ b/patches/64bit/Terraria.Localization.Content/fr-FR.tModLoader.json.patch
@@ -1,12 +1,16 @@
 --- src/tModLoader/Terraria.Localization.Content/fr-FR.tModLoader.json
 +++ src/64bit/Terraria.Localization.Content/fr-FR.tModLoader.json
-@@ -348,6 +_,10 @@
+@@ -348,6 +_,14 @@
  		"WorldIODataException": "Le jeu a rencontré un problème de données de Mod pour un monde.",
  		"ServerCrash": "Crash du serveur : {0}\n{1}\n\nMerci de vérifier le server.log pour déterminer si un mod est fautif, sinon rendez vous dans le canal de chat #support du Discord de tModLoader"
  
 +		// Misc. 64bit
 +		//"XL": "XL",
-+  //"Support": "Support",
++		//"Support": "Support",
++  //"64bitDiscord": "tModLoader 64bit Discord",
++		//"tModDiscord": "Official tModLoader Discord",
++		//"PatreonDradon": "Support Dradon on Patreon!",
++		//"PatreontMod": "Support tModLoader on Patreon!",
 +
  		// MessageBox
  		// "ContentFolderNotFound": "Terraria Content folder not found. If you installed tModLoader through Steam, make sure that Terraria is installed. If not, make sure to install tModLoader in a folder nested within the Terraria install directory or a folder next to the Terraria install directory.",

--- a/patches/64bit/Terraria.Localization.Content/fr-FR.tModLoader.json.patch
+++ b/patches/64bit/Terraria.Localization.Content/fr-FR.tModLoader.json.patch
@@ -1,11 +1,12 @@
 --- src/tModLoader/Terraria.Localization.Content/fr-FR.tModLoader.json
 +++ src/64bit/Terraria.Localization.Content/fr-FR.tModLoader.json
-@@ -348,6 +_,9 @@
+@@ -348,6 +_,10 @@
  		"WorldIODataException": "Le jeu a rencontré un problème de données de Mod pour un monde.",
  		"ServerCrash": "Crash du serveur : {0}\n{1}\n\nMerci de vérifier le server.log pour déterminer si un mod est fautif, sinon rendez vous dans le canal de chat #support du Discord de tModLoader"
  
 +		// Misc. 64bit
 +		//"XL": "XL",
++  //"Support": "Support",
 +
  		// MessageBox
  		// "ContentFolderNotFound": "Terraria Content folder not found. If you installed tModLoader through Steam, make sure that Terraria is installed. If not, make sure to install tModLoader in a folder nested within the Terraria install directory or a folder next to the Terraria install directory.",

--- a/patches/64bit/Terraria.Localization.Content/fr-FR.tModLoader.json.patch
+++ b/patches/64bit/Terraria.Localization.Content/fr-FR.tModLoader.json.patch
@@ -1,16 +1,26 @@
 --- src/tModLoader/Terraria.Localization.Content/fr-FR.tModLoader.json
 +++ src/64bit/Terraria.Localization.Content/fr-FR.tModLoader.json
-@@ -348,6 +_,14 @@
+@@ -348,6 +_,24 @@
  		"WorldIODataException": "Le jeu a rencontré un problème de données de Mod pour un monde.",
  		"ServerCrash": "Crash du serveur : {0}\n{1}\n\nMerci de vérifier le server.log pour déterminer si un mod est fautif, sinon rendez vous dans le canal de chat #support du Discord de tModLoader"
  
 +		// Misc. 64bit
 +		//"XL": "XL",
 +		//"Support": "Support",
-+  //"64bitDiscord": "tModLoader 64bit Discord",
++		//"64bitDiscord": "tModLoader 64bit Discord",
 +		//"tModDiscord": "Official tModLoader Discord",
 +		//"PatreonDradon": "Support Dradon on Patreon!",
 +		//"PatreontMod": "Support tModLoader on Patreon!",
++		//"VanillaMode": "Switch to 64bit vanillla",
++		//"tModMode": "Switch to 64bit tML",
++		//"DisableLite": "Disable Lite mode",
++		//"EnableLite": "Enable Lite mode",
++		//"RunningBitMode": "(Running in {0}bit mode)",
++		//"GoG": "GoG",
++		//"Steam": "Steam",
++		//"UnfinishedFeature": "This feature is NOT finshed and will be released at a later date.\n\n\n- Dradonhunter11",
++		//"SwitchFromLite": "Your game will be switched to the full 64bit version. You will need to restart your game completely for all effects to be applied.\nIn this mode, you can generate XL worlds and larger chest limit of 2000; however, you will no longer be able to play with 32bit tML users anymore unless you switch back to Lite mode.",
++		//"SwitchToLite": "Your game will be switched to the Lite version of 64bit. You will need to restart your game completely for all effects to be applied.\nIn this mode, you will be able to play with other 32bit tML users (along with other 64bit Lite users); however, you will not be able to player with tML 64bit users who are not using the Lite version. You can always switch back to the full version of 64bit tML.",
 +
  		// MessageBox
  		// "ContentFolderNotFound": "Terraria Content folder not found. If you installed tModLoader through Steam, make sure that Terraria is installed. If not, make sure to install tModLoader in a folder nested within the Terraria install directory or a folder next to the Terraria install directory.",

--- a/patches/64bit/Terraria.Localization.Content/fr-FR.tModLoader.json.patch
+++ b/patches/64bit/Terraria.Localization.Content/fr-FR.tModLoader.json.patch
@@ -1,0 +1,12 @@
+--- src/tModLoader/Terraria.Localization.Content/fr-FR.tModLoader.json
++++ src/64bit/Terraria.Localization.Content/fr-FR.tModLoader.json
+@@ -348,6 +_,9 @@
+ 		"WorldIODataException": "Le jeu a rencontré un problème de données de Mod pour un monde.",
+ 		"ServerCrash": "Crash du serveur : {0}\n{1}\n\nMerci de vérifier le server.log pour déterminer si un mod est fautif, sinon rendez vous dans le canal de chat #support du Discord de tModLoader"
+ 
++		// Misc. 64bit
++		//"XL": "XL",
++
+ 		// MessageBox
+ 		// "ContentFolderNotFound": "Terraria Content folder not found. If you installed tModLoader through Steam, make sure that Terraria is installed. If not, make sure to install tModLoader in a folder nested within the Terraria install directory or a folder next to the Terraria install directory.",
+ 		// "MissingServerExecutable": "Looks like you didn't do a complete install. You are missing tModLoaderServer.exe. Check your install directory and read the install directions.",

--- a/patches/64bit/Terraria.Localization.Content/it-IT.tModLoader.json.patch
+++ b/patches/64bit/Terraria.Localization.Content/it-IT.tModLoader.json.patch
@@ -1,11 +1,12 @@
 --- src/tModLoader/Terraria.Localization.Content/it-IT.tModLoader.json
 +++ src/64bit/Terraria.Localization.Content/it-IT.tModLoader.json
-@@ -350,6 +_,9 @@
+@@ -350,6 +_,10 @@
  		// "WorldIODataException": "The game encountered a mod data problem for a world.",
  		// "ServerCrash": "Server crash: {0}\n{1}\n\nPlease check server.log to determine if a mod is responsible, otherwise head to #support in the tModLoader Discord",
  
 +		// Misc. 64bit
 +		//"XL": "XL",
++  //"Support": "Support",
 +
  		// MessageBox
  		// "ContentFolderNotFound": "Terraria Content folder not found. If you installed tModLoader through Steam, make sure that Terraria is installed. If not, make sure to install tModLoader in a folder nested within the Terraria install directory or a folder next to the Terraria install directory.",

--- a/patches/64bit/Terraria.Localization.Content/it-IT.tModLoader.json.patch
+++ b/patches/64bit/Terraria.Localization.Content/it-IT.tModLoader.json.patch
@@ -1,0 +1,12 @@
+--- src/tModLoader/Terraria.Localization.Content/it-IT.tModLoader.json
++++ src/64bit/Terraria.Localization.Content/it-IT.tModLoader.json
+@@ -350,6 +_,9 @@
+ 		// "WorldIODataException": "The game encountered a mod data problem for a world.",
+ 		// "ServerCrash": "Server crash: {0}\n{1}\n\nPlease check server.log to determine if a mod is responsible, otherwise head to #support in the tModLoader Discord",
+ 
++		// Misc. 64bit
++		//"XL": "XL",
++
+ 		// MessageBox
+ 		// "ContentFolderNotFound": "Terraria Content folder not found. If you installed tModLoader through Steam, make sure that Terraria is installed. If not, make sure to install tModLoader in a folder nested within the Terraria install directory or a folder next to the Terraria install directory.",
+ 		// "MissingServerExecutable": "Looks like you didn't do a complete install. You are missing tModLoaderServer.exe. Check your install directory and read the install directions.",

--- a/patches/64bit/Terraria.Localization.Content/it-IT.tModLoader.json.patch
+++ b/patches/64bit/Terraria.Localization.Content/it-IT.tModLoader.json.patch
@@ -1,16 +1,26 @@
 --- src/tModLoader/Terraria.Localization.Content/it-IT.tModLoader.json
 +++ src/64bit/Terraria.Localization.Content/it-IT.tModLoader.json
-@@ -350,6 +_,14 @@
+@@ -350,6 +_,24 @@
  		// "WorldIODataException": "The game encountered a mod data problem for a world.",
  		// "ServerCrash": "Server crash: {0}\n{1}\n\nPlease check server.log to determine if a mod is responsible, otherwise head to #support in the tModLoader Discord",
  
 +		// Misc. 64bit
 +		//"XL": "XL",
 +		//"Support": "Support",
-+  //"64bitDiscord": "tModLoader 64bit Discord",
++		//"64bitDiscord": "tModLoader 64bit Discord",
 +		//"tModDiscord": "Official tModLoader Discord",
 +		//"PatreonDradon": "Support Dradon on Patreon!",
 +		//"PatreontMod": "Support tModLoader on Patreon!",
++		//"VanillaMode": "Switch to 64bit vanillla",
++		//"tModMode": "Switch to 64bit tML",
++		//"DisableLite": "Disable Lite mode",
++		//"EnableLite": "Enable Lite mode",
++		//"RunningBitMode": "(Running in {0}bit mode)",
++		//"GoG": "GoG",
++		//"Steam": "Steam",
++		//"UnfinishedFeature": "This feature is NOT finshed and will be released at a later date.\n\n\n- Dradonhunter11",
++		//"SwitchFromLite": "Your game will be switched to the full 64bit version. You will need to restart your game completely for all effects to be applied.\nIn this mode, you can generate XL worlds and larger chest limit of 2000; however, you will no longer be able to play with 32bit tML users anymore unless you switch back to Lite mode.",
++		//"SwitchToLite": "Your game will be switched to the Lite version of 64bit. You will need to restart your game completely for all effects to be applied.\nIn this mode, you will be able to play with other 32bit tML users (along with other 64bit Lite users); however, you will not be able to player with tML 64bit users who are not using the Lite version. You can always switch back to the full version of 64bit tML.",
 +
  		// MessageBox
  		// "ContentFolderNotFound": "Terraria Content folder not found. If you installed tModLoader through Steam, make sure that Terraria is installed. If not, make sure to install tModLoader in a folder nested within the Terraria install directory or a folder next to the Terraria install directory.",

--- a/patches/64bit/Terraria.Localization.Content/it-IT.tModLoader.json.patch
+++ b/patches/64bit/Terraria.Localization.Content/it-IT.tModLoader.json.patch
@@ -1,12 +1,16 @@
 --- src/tModLoader/Terraria.Localization.Content/it-IT.tModLoader.json
 +++ src/64bit/Terraria.Localization.Content/it-IT.tModLoader.json
-@@ -350,6 +_,10 @@
+@@ -350,6 +_,14 @@
  		// "WorldIODataException": "The game encountered a mod data problem for a world.",
  		// "ServerCrash": "Server crash: {0}\n{1}\n\nPlease check server.log to determine if a mod is responsible, otherwise head to #support in the tModLoader Discord",
  
 +		// Misc. 64bit
 +		//"XL": "XL",
-+  //"Support": "Support",
++		//"Support": "Support",
++  //"64bitDiscord": "tModLoader 64bit Discord",
++		//"tModDiscord": "Official tModLoader Discord",
++		//"PatreonDradon": "Support Dradon on Patreon!",
++		//"PatreontMod": "Support tModLoader on Patreon!",
 +
  		// MessageBox
  		// "ContentFolderNotFound": "Terraria Content folder not found. If you installed tModLoader through Steam, make sure that Terraria is installed. If not, make sure to install tModLoader in a folder nested within the Terraria install directory or a folder next to the Terraria install directory.",

--- a/patches/64bit/Terraria.Localization.Content/pl-PL.tModLoader.json.patch
+++ b/patches/64bit/Terraria.Localization.Content/pl-PL.tModLoader.json.patch
@@ -1,16 +1,26 @@
 --- src/tModLoader/Terraria.Localization.Content/pl-PL.tModLoader.json
 +++ src/64bit/Terraria.Localization.Content/pl-PL.tModLoader.json
-@@ -349,6 +_,14 @@
+@@ -349,6 +_,24 @@
  		// "WorldIODataException": "The game encountered a mod data problem for a world.",
  		// "ServerCrash": "Server crash: {0}\n{1}\n\nPlease check server.log to determine if a mod is responsible, otherwise head to #support in the tModLoader Discord",
  
 +		// Misc. 64bit
 +		//"XL": "XL",
 +		//"Support": "Support",
-+  //"64bitDiscord": "tModLoader 64bit Discord",
++		//"64bitDiscord": "tModLoader 64bit Discord",
 +		//"tModDiscord": "Official tModLoader Discord",
 +		//"PatreonDradon": "Support Dradon on Patreon!",
 +		//"PatreontMod": "Support tModLoader on Patreon!",
++		//"VanillaMode": "Switch to 64bit vanillla",
++		//"tModMode": "Switch to 64bit tML",
++		//"DisableLite": "Disable Lite mode",
++		//"EnableLite": "Enable Lite mode",
++		//"RunningBitMode": "(Running in {0}bit mode)",
++		//"GoG": "GoG",
++		//"Steam": "Steam",
++		//"UnfinishedFeature": "This feature is NOT finshed and will be released at a later date.\n\n\n- Dradonhunter11",
++		//"SwitchFromLite": "Your game will be switched to the full 64bit version. You will need to restart your game completely for all effects to be applied.\nIn this mode, you can generate XL worlds and larger chest limit of 2000; however, you will no longer be able to play with 32bit tML users anymore unless you switch back to Lite mode.",
++		//"SwitchToLite": "Your game will be switched to the Lite version of 64bit. You will need to restart your game completely for all effects to be applied.\nIn this mode, you will be able to play with other 32bit tML users (along with other 64bit Lite users); however, you will not be able to player with tML 64bit users who are not using the Lite version. You can always switch back to the full version of 64bit tML.",
 +
  		// MessageBox
  		// "ContentFolderNotFound": "Terraria Content folder not found. If you installed tModLoader through Steam, make sure that Terraria is installed. If not, make sure to install tModLoader in a folder nested within the Terraria install directory or a folder next to the Terraria install directory.",

--- a/patches/64bit/Terraria.Localization.Content/pl-PL.tModLoader.json.patch
+++ b/patches/64bit/Terraria.Localization.Content/pl-PL.tModLoader.json.patch
@@ -1,11 +1,12 @@
 --- src/tModLoader/Terraria.Localization.Content/pl-PL.tModLoader.json
 +++ src/64bit/Terraria.Localization.Content/pl-PL.tModLoader.json
-@@ -349,6 +_,9 @@
+@@ -349,6 +_,10 @@
  		// "WorldIODataException": "The game encountered a mod data problem for a world.",
  		// "ServerCrash": "Server crash: {0}\n{1}\n\nPlease check server.log to determine if a mod is responsible, otherwise head to #support in the tModLoader Discord",
  
 +		// Misc. 64bit
 +		//"XL": "XL",
++  //"Support": "Support",
 +
  		// MessageBox
  		// "ContentFolderNotFound": "Terraria Content folder not found. If you installed tModLoader through Steam, make sure that Terraria is installed. If not, make sure to install tModLoader in a folder nested within the Terraria install directory or a folder next to the Terraria install directory.",

--- a/patches/64bit/Terraria.Localization.Content/pl-PL.tModLoader.json.patch
+++ b/patches/64bit/Terraria.Localization.Content/pl-PL.tModLoader.json.patch
@@ -1,0 +1,12 @@
+--- src/tModLoader/Terraria.Localization.Content/pl-PL.tModLoader.json
++++ src/64bit/Terraria.Localization.Content/pl-PL.tModLoader.json
+@@ -349,6 +_,9 @@
+ 		// "WorldIODataException": "The game encountered a mod data problem for a world.",
+ 		// "ServerCrash": "Server crash: {0}\n{1}\n\nPlease check server.log to determine if a mod is responsible, otherwise head to #support in the tModLoader Discord",
+ 
++		// Misc. 64bit
++		//"XL": "XL",
++
+ 		// MessageBox
+ 		// "ContentFolderNotFound": "Terraria Content folder not found. If you installed tModLoader through Steam, make sure that Terraria is installed. If not, make sure to install tModLoader in a folder nested within the Terraria install directory or a folder next to the Terraria install directory.",
+ 		// "MissingServerExecutable": "Looks like you didn't do a complete install. You are missing tModLoaderServer.exe. Check your install directory and read the install directions.",

--- a/patches/64bit/Terraria.Localization.Content/pl-PL.tModLoader.json.patch
+++ b/patches/64bit/Terraria.Localization.Content/pl-PL.tModLoader.json.patch
@@ -1,12 +1,16 @@
 --- src/tModLoader/Terraria.Localization.Content/pl-PL.tModLoader.json
 +++ src/64bit/Terraria.Localization.Content/pl-PL.tModLoader.json
-@@ -349,6 +_,10 @@
+@@ -349,6 +_,14 @@
  		// "WorldIODataException": "The game encountered a mod data problem for a world.",
  		// "ServerCrash": "Server crash: {0}\n{1}\n\nPlease check server.log to determine if a mod is responsible, otherwise head to #support in the tModLoader Discord",
  
 +		// Misc. 64bit
 +		//"XL": "XL",
-+  //"Support": "Support",
++		//"Support": "Support",
++  //"64bitDiscord": "tModLoader 64bit Discord",
++		//"tModDiscord": "Official tModLoader Discord",
++		//"PatreonDradon": "Support Dradon on Patreon!",
++		//"PatreontMod": "Support tModLoader on Patreon!",
 +
  		// MessageBox
  		// "ContentFolderNotFound": "Terraria Content folder not found. If you installed tModLoader through Steam, make sure that Terraria is installed. If not, make sure to install tModLoader in a folder nested within the Terraria install directory or a folder next to the Terraria install directory.",

--- a/patches/64bit/Terraria.Localization.Content/pt-BR.tModLoader.json.patch
+++ b/patches/64bit/Terraria.Localization.Content/pt-BR.tModLoader.json.patch
@@ -1,0 +1,12 @@
+--- src/tModLoader/Terraria.Localization.Content/pt-BR.tModLoader.json
++++ src/64bit/Terraria.Localization.Content/pt-BR.tModLoader.json
+@@ -348,6 +_,9 @@
+ 		// "WorldIODataException": "The game encountered a mod data problem for a world.",
+ 		// "ServerCrash": "Server crash: {0}\n{1}\n\nPlease check server.log to determine if a mod is responsible, otherwise head to #support in the tModLoader Discord",
+ 
++		// Misc. 64bit
++		//"XL": "XL",
++
+ 		// MessageBox
+ 		// "ContentFolderNotFound": "Terraria Content folder not found. If you installed tModLoader through Steam, make sure that Terraria is installed. If not, make sure to install tModLoader in a folder nested within the Terraria install directory or a folder next to the Terraria install directory.",
+ 		// "MissingServerExecutable": "Looks like you didn't do a complete install. You are missing tModLoaderServer.exe. Check your install directory and read the install directions.",

--- a/patches/64bit/Terraria.Localization.Content/pt-BR.tModLoader.json.patch
+++ b/patches/64bit/Terraria.Localization.Content/pt-BR.tModLoader.json.patch
@@ -1,12 +1,16 @@
 --- src/tModLoader/Terraria.Localization.Content/pt-BR.tModLoader.json
 +++ src/64bit/Terraria.Localization.Content/pt-BR.tModLoader.json
-@@ -348,6 +_,10 @@
+@@ -348,6 +_,14 @@
  		// "WorldIODataException": "The game encountered a mod data problem for a world.",
  		// "ServerCrash": "Server crash: {0}\n{1}\n\nPlease check server.log to determine if a mod is responsible, otherwise head to #support in the tModLoader Discord",
  
 +		// Misc. 64bit
 +		//"XL": "XL",
-+  //"Support": "Support",
++		//"Support": "Support",
++  //"64bitDiscord": "tModLoader 64bit Discord",
++		//"tModDiscord": "Official tModLoader Discord",
++		//"PatreonDradon": "Support Dradon on Patreon!",
++		//"PatreontMod": "Support tModLoader on Patreon!",
 +
  		// MessageBox
  		// "ContentFolderNotFound": "Terraria Content folder not found. If you installed tModLoader through Steam, make sure that Terraria is installed. If not, make sure to install tModLoader in a folder nested within the Terraria install directory or a folder next to the Terraria install directory.",

--- a/patches/64bit/Terraria.Localization.Content/pt-BR.tModLoader.json.patch
+++ b/patches/64bit/Terraria.Localization.Content/pt-BR.tModLoader.json.patch
@@ -1,11 +1,12 @@
 --- src/tModLoader/Terraria.Localization.Content/pt-BR.tModLoader.json
 +++ src/64bit/Terraria.Localization.Content/pt-BR.tModLoader.json
-@@ -348,6 +_,9 @@
+@@ -348,6 +_,10 @@
  		// "WorldIODataException": "The game encountered a mod data problem for a world.",
  		// "ServerCrash": "Server crash: {0}\n{1}\n\nPlease check server.log to determine if a mod is responsible, otherwise head to #support in the tModLoader Discord",
  
 +		// Misc. 64bit
 +		//"XL": "XL",
++  //"Support": "Support",
 +
  		// MessageBox
  		// "ContentFolderNotFound": "Terraria Content folder not found. If you installed tModLoader through Steam, make sure that Terraria is installed. If not, make sure to install tModLoader in a folder nested within the Terraria install directory or a folder next to the Terraria install directory.",

--- a/patches/64bit/Terraria.Localization.Content/pt-BR.tModLoader.json.patch
+++ b/patches/64bit/Terraria.Localization.Content/pt-BR.tModLoader.json.patch
@@ -1,16 +1,26 @@
 --- src/tModLoader/Terraria.Localization.Content/pt-BR.tModLoader.json
 +++ src/64bit/Terraria.Localization.Content/pt-BR.tModLoader.json
-@@ -348,6 +_,14 @@
+@@ -348,6 +_,24 @@
  		// "WorldIODataException": "The game encountered a mod data problem for a world.",
  		// "ServerCrash": "Server crash: {0}\n{1}\n\nPlease check server.log to determine if a mod is responsible, otherwise head to #support in the tModLoader Discord",
  
 +		// Misc. 64bit
 +		//"XL": "XL",
 +		//"Support": "Support",
-+  //"64bitDiscord": "tModLoader 64bit Discord",
++		//"64bitDiscord": "tModLoader 64bit Discord",
 +		//"tModDiscord": "Official tModLoader Discord",
 +		//"PatreonDradon": "Support Dradon on Patreon!",
 +		//"PatreontMod": "Support tModLoader on Patreon!",
++		//"VanillaMode": "Switch to 64bit vanillla",
++		//"tModMode": "Switch to 64bit tML",
++		//"DisableLite": "Disable Lite mode",
++		//"EnableLite": "Enable Lite mode",
++		//"RunningBitMode": "(Running in {0}bit mode)",
++		//"GoG": "GoG",
++		//"Steam": "Steam",
++		//"UnfinishedFeature": "This feature is NOT finshed and will be released at a later date.\n\n\n- Dradonhunter11",
++		//"SwitchFromLite": "Your game will be switched to the full 64bit version. You will need to restart your game completely for all effects to be applied.\nIn this mode, you can generate XL worlds and larger chest limit of 2000; however, you will no longer be able to play with 32bit tML users anymore unless you switch back to Lite mode.",
++		//"SwitchToLite": "Your game will be switched to the Lite version of 64bit. You will need to restart your game completely for all effects to be applied.\nIn this mode, you will be able to play with other 32bit tML users (along with other 64bit Lite users); however, you will not be able to player with tML 64bit users who are not using the Lite version. You can always switch back to the full version of 64bit tML.",
 +
  		// MessageBox
  		// "ContentFolderNotFound": "Terraria Content folder not found. If you installed tModLoader through Steam, make sure that Terraria is installed. If not, make sure to install tModLoader in a folder nested within the Terraria install directory or a folder next to the Terraria install directory.",

--- a/patches/64bit/Terraria.Localization.Content/ru-RU.tModLoader.json.patch
+++ b/patches/64bit/Terraria.Localization.Content/ru-RU.tModLoader.json.patch
@@ -1,12 +1,16 @@
 --- src/tModLoader/Terraria.Localization.Content/ru-RU.tModLoader.json
 +++ src/64bit/Terraria.Localization.Content/ru-RU.tModLoader.json
-@@ -348,6 +_,10 @@
+@@ -348,6 +_,14 @@
  		"WorldIODataException": "Произошла ошибка во время загрузки мод-данных этого мира.",
  		"ServerCrash": "Сбой сервера: {0}\n{1}\n\nПожалуйста, проверьте server.log чтобы понять если в этом виноват какой-либо мод. Иначе, идите в текстовый канал #support в Discord сервере tModLoader, и не забудьте отправить этот самый файл."
  
 +		// Misc. 64bit
 +		//"XL": "XL",
 +		//"Support": "Support",
++  //"64bitDiscord": "tModLoader 64bit Discord",
++		//"tModDiscord": "Official tModLoader Discord",
++		//"PatreonDradon": "Support Dradon on Patreon!",
++		//"PatreontMod": "Support tModLoader on Patreon!",
 +
  		// MessageBox
  		// "ContentFolderNotFound": "Terraria Content folder not found. If you installed tModLoader through Steam, make sure that Terraria is installed. If not, make sure to install tModLoader in a folder nested within the Terraria install directory or a folder next to the Terraria install directory.",

--- a/patches/64bit/Terraria.Localization.Content/ru-RU.tModLoader.json.patch
+++ b/patches/64bit/Terraria.Localization.Content/ru-RU.tModLoader.json.patch
@@ -1,11 +1,12 @@
 --- src/tModLoader/Terraria.Localization.Content/ru-RU.tModLoader.json
 +++ src/64bit/Terraria.Localization.Content/ru-RU.tModLoader.json
-@@ -348,6 +_,9 @@
+@@ -348,6 +_,10 @@
  		"WorldIODataException": "Произошла ошибка во время загрузки мод-данных этого мира.",
  		"ServerCrash": "Сбой сервера: {0}\n{1}\n\nПожалуйста, проверьте server.log чтобы понять если в этом виноват какой-либо мод. Иначе, идите в текстовый канал #support в Discord сервере tModLoader, и не забудьте отправить этот самый файл."
  
 +		// Misc. 64bit
 +		//"XL": "XL",
++		//"Support": "Support",
 +
  		// MessageBox
  		// "ContentFolderNotFound": "Terraria Content folder not found. If you installed tModLoader through Steam, make sure that Terraria is installed. If not, make sure to install tModLoader in a folder nested within the Terraria install directory or a folder next to the Terraria install directory.",

--- a/patches/64bit/Terraria.Localization.Content/ru-RU.tModLoader.json.patch
+++ b/patches/64bit/Terraria.Localization.Content/ru-RU.tModLoader.json.patch
@@ -1,0 +1,12 @@
+--- src/tModLoader/Terraria.Localization.Content/ru-RU.tModLoader.json
++++ src/64bit/Terraria.Localization.Content/ru-RU.tModLoader.json
+@@ -348,6 +_,9 @@
+ 		"WorldIODataException": "Произошла ошибка во время загрузки мод-данных этого мира.",
+ 		"ServerCrash": "Сбой сервера: {0}\n{1}\n\nПожалуйста, проверьте server.log чтобы понять если в этом виноват какой-либо мод. Иначе, идите в текстовый канал #support в Discord сервере tModLoader, и не забудьте отправить этот самый файл."
+ 
++		// Misc. 64bit
++		//"XL": "XL",
++
+ 		// MessageBox
+ 		// "ContentFolderNotFound": "Terraria Content folder not found. If you installed tModLoader through Steam, make sure that Terraria is installed. If not, make sure to install tModLoader in a folder nested within the Terraria install directory or a folder next to the Terraria install directory.",
+ 		// "MissingServerExecutable": "Looks like you didn't do a complete install. You are missing tModLoaderServer.exe. Check your install directory and read the install directions.",

--- a/patches/64bit/Terraria.Localization.Content/ru-RU.tModLoader.json.patch
+++ b/patches/64bit/Terraria.Localization.Content/ru-RU.tModLoader.json.patch
@@ -1,16 +1,26 @@
 --- src/tModLoader/Terraria.Localization.Content/ru-RU.tModLoader.json
 +++ src/64bit/Terraria.Localization.Content/ru-RU.tModLoader.json
-@@ -348,6 +_,14 @@
+@@ -348,6 +_,24 @@
  		"WorldIODataException": "Произошла ошибка во время загрузки мод-данных этого мира.",
  		"ServerCrash": "Сбой сервера: {0}\n{1}\n\nПожалуйста, проверьте server.log чтобы понять если в этом виноват какой-либо мод. Иначе, идите в текстовый канал #support в Discord сервере tModLoader, и не забудьте отправить этот самый файл."
  
 +		// Misc. 64bit
 +		//"XL": "XL",
 +		//"Support": "Support",
-+  //"64bitDiscord": "tModLoader 64bit Discord",
++		//"64bitDiscord": "tModLoader 64bit Discord",
 +		//"tModDiscord": "Official tModLoader Discord",
 +		//"PatreonDradon": "Support Dradon on Patreon!",
 +		//"PatreontMod": "Support tModLoader on Patreon!",
++		//"VanillaMode": "Switch to 64bit vanillla",
++		//"tModMode": "Switch to 64bit tML",
++		//"DisableLite": "Disable Lite mode",
++		//"EnableLite": "Enable Lite mode",
++		//"RunningBitMode": "(Running in {0}bit mode)",
++		//"GoG": "GoG",
++		//"Steam": "Steam",
++		//"UnfinishedFeature": "This feature is NOT finshed and will be released at a later date.\n\n\n- Dradonhunter11",
++		//"SwitchFromLite": "Your game will be switched to the full 64bit version. You will need to restart your game completely for all effects to be applied.\nIn this mode, you can generate XL worlds and larger chest limit of 2000; however, you will no longer be able to play with 32bit tML users anymore unless you switch back to Lite mode.",
++		//"SwitchToLite": "Your game will be switched to the Lite version of 64bit. You will need to restart your game completely for all effects to be applied.\nIn this mode, you will be able to play with other 32bit tML users (along with other 64bit Lite users); however, you will not be able to player with tML 64bit users who are not using the Lite version. You can always switch back to the full version of 64bit tML.",
 +
  		// MessageBox
  		// "ContentFolderNotFound": "Terraria Content folder not found. If you installed tModLoader through Steam, make sure that Terraria is installed. If not, make sure to install tModLoader in a folder nested within the Terraria install directory or a folder next to the Terraria install directory.",

--- a/patches/64bit/Terraria.Localization.Content/zh-Hans.tModLoader.json.patch
+++ b/patches/64bit/Terraria.Localization.Content/zh-Hans.tModLoader.json.patch
@@ -1,0 +1,12 @@
+--- src/tModLoader/Terraria.Localization.Content/zh-Hans.tModLoader.json
++++ src/64bit/Terraria.Localization.Content/zh-Hans.tModLoader.json
+@@ -349,6 +_,9 @@
+ 		"WorldIODataException": "游戏遇到一个关于地图的模组数据问题.",
+ 		"ServerCrash": "服务器崩溃: {0}\n{1}\n\n请检查[server.log]以确定是否由模组导致, 否则请转到tModLoader Discord群组中的#support频道",
+ 
++		// Misc. 64bit
++		//"XL": "XL",
++
+ 		// MessageBox
+ 		"ContentFolderNotFound": "无法检测到原版Terraria的Content资源文件夹\n如果你是通过Steam安装的tModLoader，请确保你也安装了Terraria\n否则，请确保你的tModLoader安装在原版Terraria的文件夹或与原版Terraria处于同级",
+ 		"MissingServerExecutable": "安装文件不完整（文件tModLoaderServer.exe缺失），无法启动服务器。请阅读教程并重新安装。",

--- a/patches/64bit/Terraria.ModLoader.UI/Interface.cs.patch
+++ b/patches/64bit/Terraria.ModLoader.UI/Interface.cs.patch
@@ -31,7 +31,7 @@
 +			buttonIndex++;
 +			numButtons++;
 +
-+			buttonNames[buttonIndex] = "Support";
++			buttonNames[buttonIndex] = Language.GetTextValue("tModLoader.Support");
 +			if (selectedMenu == buttonIndex) {
 +				Main.PlaySound(10, -1, -1, 1);
 +				Main.menuMode = supportID;
@@ -87,9 +87,7 @@
  		}
  
  		internal static void ServerModMenu() {
-@@ -379,14 +_,15 @@
- 			// MessageBox.Show fails on Mac, this method will open a text file to show a message.
- 			caption = caption ?? "Terraria: Error" + $" ({ModLoader.versionedName})";
+@@ -381,12 +_,13 @@
  			string message = Language.GetTextValue("tModLoader.ClientLogHint", text, Path.Combine(Main.SavePath, "Logs"));
  			if(Language.ActiveCulture == null) // Simple backup approach in case error happens before localization is loaded
  				message = string.Format("{0}\n\nA client.log file containing error information has been generated in\n{1}\n(You will need to share this file if asking for help)", text, Path.Combine(Main.SavePath, "Logs"));

--- a/patches/64bit/Terraria.ModLoader.UI/Interface.cs.patch
+++ b/patches/64bit/Terraria.ModLoader.UI/Interface.cs.patch
@@ -49,28 +49,28 @@
 +				numButtons = 5;
 +				buttonVerticalSpacing[numButtons - 1] = 18;
 +				int buttonIndex = 0;
-+				buttonNames[buttonIndex] = "tModLoader 64bit discord";
++				buttonNames[buttonIndex] = Language.GetTextValue("tModLoader.64bitDiscord");
 +				if (selectedMenu == buttonIndex) {
 +					Main.PlaySound(SoundID.MenuOpen);
 +					Process.Start("https://discord.gg/DY8cx5T");
 +				}
 +
 +				buttonIndex++;
-+				buttonNames[buttonIndex] = "Official tModLoader discord";
++				buttonNames[buttonIndex] = Language.GetTextValue("tModLoader.tModDiscord");
 +				if (selectedMenu == buttonIndex) {
 +					Main.PlaySound(SoundID.MenuOpen);
 +					Process.Start("https://discord.gg/RMZCqq6");
 +				}
 +
 +				buttonIndex++;
-+				buttonNames[buttonIndex] = "Support Dradon on Patreon!";
++				buttonNames[buttonIndex] = Language.GetTextValue("tModLoader.PatreonDradon");
 +				if (selectedMenu == buttonIndex) {
 +					Main.PlaySound(SoundID.MenuOpen);
 +					Process.Start("https://www.patreon.com/dradonhunter11");
 +				}
 +
 +				buttonIndex++;
-+				buttonNames[buttonIndex] = "Support tModLoader on Patreon!";
++				buttonNames[buttonIndex] = Language.GetTextValue("tModLoader.PatreontMod");
 +				if (selectedMenu == buttonIndex) {
 +					Main.PlaySound(SoundID.MenuOpen);
 +					Process.Start("https://www.patreon.com/tModLoader");

--- a/patches/64bit/Terraria.ModLoader.x64bit/Core64.cs
+++ b/patches/64bit/Terraria.ModLoader.x64bit/Core64.cs
@@ -9,6 +9,7 @@ using ReLogic.Graphics;
 using Terraria.DataStructures;
 using Terraria.ID;
 using Terraria.IO;
+using Terraria.Localization;
 using Terraria.ModLoader.Default;
 using Terraria.ModLoader.Engine;
 using Terraria.ModLoader.UI;
@@ -54,54 +55,52 @@ namespace Terraria.ModLoader.x64bit
 			Main.PlayerPath = Path.Combine(Main.SavePath, "ModLoader", "Players");
 		}
 
-		internal static void DrawPatreon(SpriteBatch sb, int num109, int num110, int num111, bool hasFocus, Color color12) {
-			string patreonShortURL = !vanillaMode ? "Switch to vanilla mode" : "Switch to TML";
-			string tmlModeString = liteMode ? "Disable lite mode" : "Enable lite mode";
+		internal static void DrawPatreon(SpriteBatch sb, int loopNum, int offsetX, int offsetY, bool hasFocus, Color color12) {
+			// TODO: Localization for vanilla, tml, and lite modes when they're actually used
+			string patreonShortURL = !vanillaMode ? Language.GetTextValue("tModLoader.VanillaMode") : Language.GetTextValue("tModLoader.tModMode");
+			string tmlModeString = liteMode ? Language.GetTextValue("tModLoader.DisableLite") : Language.GetTextValue("tModLoader.EnableLite");
 			bool showPatreon = Main.menuMode == 0;
-			string architecture = $"(Running in {(Environment.Is64BitProcess ? 64.ToString() : 32.ToString())} bit mode)";
-			string GoG = InstallVerifier.IsGoG ? "GoG" : "Steam";
+			string architecture = Language.GetTextValue("tModLoader.RunningBitMode", Environment.Is64BitProcess ? 64.ToString() : 32.ToString());
+			string GoG = InstallVerifier.IsGoG ? Language.GetTextValue("tModLoader.GoG") : Language.GetTextValue("tModLoader.Steam");
 			string drawVersion;
-			if (vanillaMode) {
+
+			if (vanillaMode)
 				drawVersion = Main.versionNumber;
-			}
-			else {
+			else
 				drawVersion = Main.versionNumber + Environment.NewLine + ModLoader.versionedName + $" - {architecture} {GoG} {PlatformUtilities.RunningPlatform()}";
-			}
 
 			Vector2 origin3 = Main.fontMouseText.MeasureString(drawVersion);
 			origin3.X *= 0.5f;
 			origin3.Y *= 0.5f;
-			Main.spriteBatch.DrawString(Main.fontMouseText, drawVersion, new Vector2(origin3.X + num110 + 10f, Main.screenHeight - origin3.Y - num111 + 2f), color12, 0f, origin3, 1f, SpriteEffects.None, 0f);
-			if (num109 == 4) {
-				color12 = new Microsoft.Xna.Framework.Color(127, 191, 191, 76);
-			}
 
-			if (Main.menuMode == 10002 && vanillaMode) {
+			Main.spriteBatch.DrawString(Main.fontMouseText, drawVersion, new Vector2(origin3.X + offsetX + 10f, Main.screenHeight - origin3.Y - offsetY + 2f), color12, 0f, origin3, 1f, SpriteEffects.None, 0f);
+
+			if (loopNum == 4)
+				color12 = new Color(127, 191, 191, 76);
+
+			if (Main.menuMode == 10002 && vanillaMode)
 				Main.menuMode = 0;
-			}
 
 			if (showPatreon) {
 				Vector2 urlSize = Main.fontMouseText.MeasureString(patreonShortURL);
-				Main.spriteBatch.DrawString(Main.fontMouseText, patreonShortURL, new Vector2(num110 + 10f, Main.screenHeight - origin3.Y - 50f - num111 + 2f), color12, 0f, Vector2.Zero, 1f, SpriteEffects.None, 0f);
-				if (num109 == 4 && Main.mouseLeftRelease && Main.mouseLeft && new Microsoft.Xna.Framework.Rectangle((int)(num110 + 10f), (int)(Main.screenHeight - origin3.Y - 50f - num111 + 2f), (int)urlSize.X, (int)origin3.Y).Contains(new Microsoft.Xna.Framework.Point(Main.mouseX, Main.mouseY)) && hasFocus) {
+				Main.spriteBatch.DrawString(Main.fontMouseText, patreonShortURL, new Vector2(offsetX + 10f, Main.screenHeight - origin3.Y - 50f - offsetY + 2f), color12, 0f, Vector2.Zero, 1f, SpriteEffects.None, 0f);
+
+				if (loopNum == 4 && Main.mouseLeftRelease && Main.mouseLeft && new Rectangle((int)(offsetX + 10f), (int)(Main.screenHeight - origin3.Y - 50f - offsetY + 2f), (int)urlSize.X, (int)origin3.Y).Contains(new Point(Main.mouseX, Main.mouseY)) && hasFocus) {
 					Main.PlaySound(SoundID.MenuOpen);
-					//vanillaMode = !vanillaMode;
-					//Main.SaveSettings();
-					//Interface.infoMessage.Show("You'll need to restart the game so that the necessary change can apply.", 0, null, "Restart", () => Environment.Exit(0));
-					Interface.infoMessage.Show("This feature is note completely done and will be released at a further time.\n\n\n-Dradonhunter11", 0);
+					/*vanillaMode = !vanillaMode;
+					Main.SaveSettings();
+					Interface.infoMessage.Show("You'll need to restart the game so that the necessary change can apply.", 0, null, "Restart", () => Environment.Exit(0));*/
+					Interface.infoMessage.Show(Language.GetTextValue("tModLoader.UnfinishedFeature"), 0);
 				}
 
 				if (!vanillaMode) {
 					urlSize = Main.fontMouseText.MeasureString(tmlModeString);
-					Main.spriteBatch.DrawString(Main.fontMouseText, tmlModeString, new Vector2(num110 + 10f, Main.screenHeight - origin3.Y - 72f - num111 + 2f), color12, 0f, Vector2.Zero, 1f, SpriteEffects.None, 0f);
-					if (num109 == 4 && Main.mouseLeftRelease && Main.mouseLeft && new Microsoft.Xna.Framework.Rectangle((int)(num110 + 10f), (int)(Main.screenHeight - origin3.Y - 72f - num111 + 2f), (int)urlSize.X, (int)origin3.Y).Contains(new Microsoft.Xna.Framework.Point(Main.mouseX, Main.mouseY)) && hasFocus) {
-						string message = liteMode ? "Your game will be switched to the full tML 64bit version. You will need to restart your game completely to have the effect applied.\n" +
-													  "In this mode you can generate an XL world, and allows for a chest limit of 2000. However, you can't play with 32bit anymore unless you switch back to tML64bit lite mode." :
-							"Your game will be switched to the tML 64bit lite mode. You will need to restart your game completely to have the effect applied.\n" +
-							"In this mode, you can play with other 32bit tModLoader clients and other tModLoader 64 bit lite users, but cannot play with tML64bit users in full mode. You can always switch back to the full tML64bit.";
+					Main.spriteBatch.DrawString(Main.fontMouseText, tmlModeString, new Vector2(offsetX + 10f, Main.screenHeight - origin3.Y - 72f - offsetY + 2f), color12, 0f, Vector2.Zero, 1f, SpriteEffects.None, 0f);
+					if (loopNum == 4 && Main.mouseLeftRelease && Main.mouseLeft && new Microsoft.Xna.Framework.Rectangle((int)(offsetX + 10f), (int)(Main.screenHeight - origin3.Y - 72f - offsetY + 2f), (int)urlSize.X, (int)origin3.Y).Contains(new Microsoft.Xna.Framework.Point(Main.mouseX, Main.mouseY)) && hasFocus) {
+						string message = liteMode ? Language.GetTextValue("tModLoader.SwitchFromLite") : Language.GetTextValue("tModLoader.SwitchToLite");
 
 						Main.PlaySound(SoundID.MenuOpen);
-						Interface.infoMessage.SpecialShow(message, 0, null, "Back", "Apply", () => {
+						Interface.infoMessage.SpecialShow(message, 0, null, Language.GetTextValue("UI.Back"), Language.GetTextValue("LegacyMenu.134"), () => { // 134: Apply
 							liteMode = !liteMode;
 							Main.SaveSettings();
 							Environment.Exit(0);

--- a/patches/64bit/Terraria/Program.cs.patch
+++ b/patches/64bit/Terraria/Program.cs.patch
@@ -31,7 +31,7 @@
  			return type.GetMethods(BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
  #else
  			return type.GetMethods();
-@@ -204,89 +_,135 @@
+@@ -204,89 +_,137 @@
  		// some versions of the .NET runtime will run the Main static initilizer as soon as LaunchGame is invoked
  		// causing Main.SavePath to be initialized before LaunchParameters is parsed.
  		// moving arg parsing to a separate function avoids this
@@ -43,20 +43,22 @@
 +		public static void LaunchGame(string[] args, bool monoArgs = false)
 +		{
 +#if FNA && CLIENT
++			// I doubt localization would work here
 +			if (!Environment.Is64BitOperatingSystem) {
-+				MessageBox.Show("Your current OS has been detected as a 32bit OS\n" +
-+				                "Unfortunately, tModLoader 64 bit currently has no support for 32 bit operating systems. You will have to upgrade your PC if you wish to use tModLoader 64 bit.\n" +
-+				                "There may be an update that will support 32 bit systems in the distant future.", "Terraria.exe", MessageBoxButtons.OK);
++				MessageBox.Show("Your current OS has been detected as a 32bit OS!" +
++					"\nUnfortunately, tModLoader 64bit currently does not support 32bit operating systems. You will have to upgrade your PC if you wish to use tModLoader 64bit." +
++					"\nThere may be an update that will support 32bit systems in the future.", "Terraria.exe", MessageBoxButtons.OK);
 +				Environment.Exit(1);
 +			}
 +
 +			//This check here if the proper VCRedist is installed on windows, should take care of the Faudio problem for some user (other need to update their driver)
 +			if (PlatformUtilities.IsWindows) {
 +				if (!PlatformUtilities.RegisteryKeyInstalled(@"SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\x64")) {
-+					MessageBox.Show("You are missing the VC Redist required for the Faudio.dll.\n" +
-+					                "Now executing the VC redist installer included with this package.\n" +
-+					                "If you have additional problems, you can join our discord server for assistance.\n" +
-+					                "link: https://discord.gg/DY8cx5T \n", "Terraria.exe", MessageBoxButtons.OK);
++					MessageBox.Show("You are missing VC Redist, which is required for Faudio.dll." +
++						"\nNow executing the VC Redist installer included with this package." +
++						"\nIf you have additional problems, you can join our Discord server for assistance:" +
++						"\nhttps://discord.gg/DY8cx5T" +
++						"\n", "Terraria.exe", MessageBoxButtons.OK);
 +					ProcessStartInfo installerStartInfo = new ProcessStartInfo("VC_redist.x64.exe", "/quiet /norestart");
 +					Process process = Process.Start(installerStartInfo);
 +					Console.Write("Installing VC redist, please wait...");


### PR DESCRIPTION
# What is this?
This is a PR that converts all the strings added by 64Bit to localizable text.

# Why?
This is useful because it allows people who speak other languages to expand 64bit's localization since it includes text not included in 32bit.